### PR TITLE
addYoutubeCookiesSupport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,4 @@ cython_debug/
 .cursorignore
 .cursorindexingignore
 tokens_and_settings.db
+cookies/

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # ─ Python deps ───────────────────────────────────────────────────
 WORKDIR /app
 ENV DB_DIR=/app/db
-RUN mkdir -p ${DB_DIR}
+RUN mkdir -p ${DB_DIR} /app/cookies
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - redis
     volumes:
       - ./data:/app/db
+      - ./cookies:/app/cookies
 
   redis:
     image: redis:7-alpine

--- a/main.py
+++ b/main.py
@@ -36,6 +36,7 @@ async def main():
         BotCommand(command="start", description="Начать"),
         BotCommand(command="help", description="Помощь"),
         BotCommand(command="token", description="Добавить токен"),
+        BotCommand(command="cookie", description="Добавить cookies"),
     ])
 
     await dp.start_polling(bot)


### PR DESCRIPTION
## Summary
- add `/cookie` command with instructions for exporting YouTube cookies and saving user files
- require saved cookies for YouTube downloads and pass them to yt-dlp
- persist cookies via mounted volume and ignore local cookie files

## Testing
- `python -m py_compile commandsModule.py youtubeModule.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_688abe529cc48321b43e39c8efa2f872